### PR TITLE
Enabling background colour parameter on rotate

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1749,7 +1749,7 @@ class Image(object):
         return self._new(self.im.resize(size, resample, box))
 
     def rotate(self, angle, resample=NEAREST, expand=0, center=None,
-               translate=None):
+               translate=None, backgroundcolor=None):
         """
         Returns a rotated copy of this image.  This method returns a
         copy of this image, rotated the given number of degrees counter
@@ -1771,6 +1771,7 @@ class Image(object):
         :param center: Optional center of rotation (a 2-tuple).  Origin is
            the upper left corner.  Default is the center of the image.
         :param translate: An optional post-rotate translation (a 2-tuple).
+        :param backgroundcolor: An optional color for the color outside the transformed image
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
 
@@ -1851,7 +1852,7 @@ class Image(object):
                                              matrix)
             w, h = nw, nh
 
-        return self.transform((w, h), AFFINE, matrix, resample)
+        return self.transform((w, h), AFFINE, matrix, resample, fillcolor=backgroundcolor)
 
     def save(self, fp, format=None, **params):
         """


### PR DESCRIPTION
Enabling the user to choose the background colour of the final rotated image rather than just black. 
parameter added: backgroundcolor
